### PR TITLE
Updated renderWebGL to check for visibility

### DIFF
--- a/dist-PIXI/neutrinoparticles.pixi.js
+++ b/dist-PIXI/neutrinoparticles.pixi.js
@@ -114,6 +114,11 @@ var PIXINeutrinoEffect = function (_PIXI$Container) {
 		value: function renderWebGL(renderer) {
 			if (!this.ready()) return;
 
+			// if the object is not visible or the alpha is 0 then no need to render this element
+			if (!this.visible || this.worldAlpha <= 0 || !this.renderable) {
+			    return;
+			}
+			
 			renderer.setObjectRenderer(renderer.emptyRenderer);
 
 			if (this.baseParent) {


### PR DESCRIPTION
I copied some code from the base implementation of [PIXI.Container.renderWebGL](https://github.com/pixijs/pixi.js/blob/4499cddfc787d5b6d42e598252e31c51af28a8e0/src/core/display/Container.js#L396) to check for visibility before rendering the particle effect. Now setting `yourEffect.visible = false` will hide the effect as expected.